### PR TITLE
Update recipe to use sha256 rather than deprecated sha1

### DIFF
--- a/verm.rb
+++ b/verm.rb
@@ -1,7 +1,7 @@
 class Verm < Formula
   homepage "https://github.com/willbryant/verm"
   url "https://github.com/willbryant/verm/archive/0.52.tar.gz"
-  sha1 "12ea5962a0c5144f5107b3ed3dc89c867c37ddb2"
+  sha256 "14a7be3c78a613d9939eac873b52abfc0c836efd64064705abb408e93c800de9"
 
   depends_on "go" => :build
 


### PR DESCRIPTION
```
% brew update && brew outdated                                                                 ~ 16:46
Already up-to-date.
Warning: Calling Formula.sha1 is deprecated!
Use Formula.sha256 instead.
/usr/local/Library/Taps/willbryant/homebrew-verm/verm.rb:4:in `<class:Verm>'
Please report this to the willbryant/verm tap!
```

Calculated as follows (with old value for comparison):

```
irb(main):002:0> Digest::SHA256.file('0.52.tar.gz').hexdigest
=> "14a7be3c78a613d9939eac873b52abfc0c836efd64064705abb408e93c800de9"
irb(main):003:0> Digest::SHA1.file('0.52.tar.gz').hexdigest
=> "12ea5962a0c5144f5107b3ed3dc89c867c37ddb2"
```
